### PR TITLE
Sexy update

### DIFF
--- a/src/main/java/com/jagex/CS2Interface.java
+++ b/src/main/java/com/jagex/CS2Interface.java
@@ -11,6 +11,7 @@ public class CS2Interface {
 
     }
 
+
     boolean setChild(int ifComp, int slotId) {
         IComponentDefinitions def = Index.getIComponentDefinitions(ifComp, slotId);
         if (def != null) {

--- a/src/main/java/com/jagex/CS2Interpreter.java
+++ b/src/main/java/com/jagex/CS2Interpreter.java
@@ -4627,11 +4627,6 @@ public class CS2Interpreter {
 
     static void chooseRenderType(CS2Executor executor) {
         int screenMode = executor.intStack[--executor.intStackPtr];
-        if(screenMode == 1 || ((screenMode == 2 || screenMode == 3) && Class158.getScreenMode() == 1))
-            if(client.GAME_STATE != 0) {//Only in lobby
-                ChatLine.appendChatMessage("You can only switch to or from fixed display in the lobby...");
-                return;
-            }
         if (screenMode >= 1 && screenMode <= 2 && !Class158.justBecameFullscreen) {
             GraphicsDevice gd = GraphicsEnvironment.getLocalGraphicsEnvironment().getDefaultScreenDevice();
             int width = gd.getDisplayMode().getWidth();

--- a/src/main/java/com/jagex/CS2Interpreter.java
+++ b/src/main/java/com/jagex/CS2Interpreter.java
@@ -3048,13 +3048,13 @@ public class CS2Interpreter {
     }
 
     static void ifSetPlace(boolean front, CS2Executor executor) {
-        int i_3 = executor.intStack[--executor.intStackPtr];
-        IComponentDefinitions icomponentdefinitions_4 = IComponentDefinitions.getDefs(i_3);
-        Interface interface_5 = Interface.INTERFACES[i_3 >> 16];
+        int interfaceId = executor.intStack[--executor.intStackPtr];
+        IComponentDefinitions iCompDefinitions = IComponentDefinitions.getDefs(interfaceId);
+        Interface inter = Interface.INTERFACES[interfaceId >> 16];
         if (front) {
-            Interface.method7554(interface_5, icomponentdefinitions_4);
+            Interface.method7554(inter, iCompDefinitions);
         } else {
-            Interface.method3710(interface_5, icomponentdefinitions_4);
+            Interface.method3710(inter, iCompDefinitions);
         }
 
     }
@@ -4627,6 +4627,11 @@ public class CS2Interpreter {
 
     static void chooseRenderType(CS2Executor executor) {
         int screenMode = executor.intStack[--executor.intStackPtr];
+        if(screenMode == 1 || ((screenMode == 2 || screenMode == 3) && Class158.getScreenMode() == 1))
+            if(client.GAME_STATE != 0) {//Only in lobby
+                ChatLine.appendChatMessage("You can only switch to or from fixed display in the lobby...");
+                return;
+            }
         if (screenMode >= 1 && screenMode <= 2 && !Class158.justBecameFullscreen) {
             GraphicsDevice gd = GraphicsEnvironment.getLocalGraphicsEnvironment().getDefaultScreenDevice();
             int width = gd.getDisplayMode().getWidth();
@@ -5895,6 +5900,8 @@ public class CS2Interpreter {
     }
 
     static void chooseFullScreen(CS2Executor executor) {
+        if(Class158.getScreenMode() == 1)
+            return;
         ChatLine.appendChatMessage("Fullscreen only works for OpenGL Java 16+");
         executor.intStackPtr -= 2;
         if (Class475.supportsFullScreen) {

--- a/src/main/java/com/jagex/CS2Interpreter.java
+++ b/src/main/java/com/jagex/CS2Interpreter.java
@@ -10,7 +10,6 @@ import java.io.File;
 import java.util.ArrayList;
 
 public class CS2Interpreter {
-    private static ArrayList<Integer> opcodes = new ArrayList<Integer>();
     public static void executeOperation(CS2Instruction operation, CS2Executor exec) {
         switch (operation) {
             case PUSH_INT:
@@ -191,10 +190,10 @@ public class CS2Interpreter {
                 method2620(exec);
                 break;
             case IF_SENDTOFRONT:
-                ifSetFront(true, exec);
+                ifSetPlace(true, exec);
                 break;
             case IF_SENDTOBACK:
-                ifSetFront(false, exec);
+                ifSetPlace(false, exec);
                 break;
             case CC_SENDTOFRONT:
                 ccSetFront(true, exec);
@@ -2297,7 +2296,7 @@ public class CS2Interpreter {
                 method301(exec);
                 break;
             case instr6707:
-                method5925(exec);
+                loadLobby(exec);
                 break;
             case instr6623:
                 method775();
@@ -3048,11 +3047,11 @@ public class CS2Interpreter {
         }
     }
 
-    static void ifSetFront(boolean bool, CS2Executor executor) {
+    static void ifSetPlace(boolean front, CS2Executor executor) {
         int i_3 = executor.intStack[--executor.intStackPtr];
         IComponentDefinitions icomponentdefinitions_4 = IComponentDefinitions.getDefs(i_3);
         Interface interface_5 = Interface.INTERFACES[i_3 >> 16];
-        if (bool) {
+        if (front) {
             Interface.method7554(interface_5, icomponentdefinitions_4);
         } else {
             Interface.method3710(interface_5, icomponentdefinitions_4);
@@ -4635,7 +4634,6 @@ public class CS2Interpreter {
             UID192.method7373(screenMode, width, height);
         } else
             Class158.justBecameFullscreen = false;
-
     }
 
     static void intLessThan(CS2Executor executor) {
@@ -5672,7 +5670,7 @@ public class CS2Interpreter {
         executor.stringStack[++executor.stringStackPtr - 1] = executor.currentClanSettings.clanName;
     }
 
-    static void method5925(CS2Executor executor) {
+    static void loadLobby(CS2Executor executor) {
         executor.stringStackPtr -= 2;
         String string_2 = (String) executor.stringStack[executor.stringStackPtr];
         String string_3 = (String) executor.stringStack[executor.stringStackPtr + 1];
@@ -5897,10 +5895,10 @@ public class CS2Interpreter {
     }
 
     static void chooseFullScreen(CS2Executor executor) {
-        ChatLine.appendChatMessage("Fullscreen is unstable use at your own peril(works depending on Java version)");
+        ChatLine.appendChatMessage("Fullscreen only works for OpenGL Java 16+");
         executor.intStackPtr -= 2;
         if (Class475.supportsFullScreen) {
-            ParticleProducer.switchRenderType(0/*renderOption*/, false);
+            ParticleProducer.switchRenderType(1/*renderOption*/, true);
             executor.intStack[++executor.intStackPtr - 1] = Engine.fullScreenFrame != null ? 1 : 0;
             GraphicsDevice gd = GraphicsEnvironment.getLocalGraphicsEnvironment().getDefaultScreenDevice();
             int width = gd.getDisplayMode().getWidth();
@@ -9468,13 +9466,15 @@ public class CS2Interpreter {
 
     static void method6678(CS2Executor executor) {
         int renderType = executor.intStack[--executor.intStackPtr];
+        System.out.println(renderType);
         if (renderType < 0 || renderType > 5) {
             renderType = 2;
         }
         if(Class158.getScreenMode() == 3) {
-            ParticleProducer.switchRenderType(renderType, Class158.getScreenMode() == 3 ? true : false);//Switching render types in fullscreen doesnt work!
+            //Only OpenGL
+            ParticleProducer.switchRenderType(1, Class158.getScreenMode() == 3 ? true : false);//Switching render types in fullscreen doesnt work!
         } else {
-            ParticleProducer.switchRenderType(renderType, Class158.getScreenMode() == 3 ? true : false);
+            ParticleProducer.switchRenderType(renderType, false);
         }
     }
 

--- a/src/main/java/com/jagex/CS2Interpreter.java
+++ b/src/main/java/com/jagex/CS2Interpreter.java
@@ -5900,7 +5900,7 @@ public class CS2Interpreter {
     }
 
     static void chooseFullScreen(CS2Executor executor) {
-        if(Class158.getScreenMode() == 1)
+        if(Class158.getScreenMode() == 1 && client.GAME_STATE != 0)
             return;
         ChatLine.appendChatMessage("Fullscreen only works for OpenGL Java 16+");
         executor.intStackPtr -= 2;

--- a/src/main/java/com/jagex/Class470.java
+++ b/src/main/java/com/jagex/Class470.java
@@ -119,6 +119,7 @@ public class Class470 {
         Field field_4;
         try {
             field_4 = Class.forName("sun.awt.Win32GraphicsDevice").getDeclaredField("valid");
+
             field_4.setAccessible(true);
             boolean bool_5 = ((Boolean) field_4.get(defaultMoniter)).booleanValue();
             if (bool_5) {

--- a/src/main/java/com/jagex/DirectXRenderer.java
+++ b/src/main/java/com/jagex/DirectXRenderer.java
@@ -39,7 +39,6 @@ public class DirectXRenderer extends HardwareRenderer {
 
     DirectXRenderer(int i_1, int i_2, long long_3, long long_5, D3DPRESENT_PARAMETERS d3dpresent_parameters_7, D3DCAPS d3dcaps_8, ImageLoader interface22_9, Index index_10, int i_11) {
         super(interface22_9, index_10, i_11, 0);
-        System.out.println("here are");
         aLongArray10271 = new long[anInt10268];
 
         try {

--- a/src/main/java/com/jagex/DirectXRenderer.java
+++ b/src/main/java/com/jagex/DirectXRenderer.java
@@ -129,7 +129,7 @@ public class DirectXRenderer extends HardwareRenderer {
             throw new RuntimeException("");
         } else {
             D3DPRESENT_PARAMETERS d3DPRESENTParameters = new D3DPRESENT_PARAMETERS(canvas);
-            d3DPRESENTParameters.Windowed = !(Class158.getScreenMode() == 3);
+            d3DPRESENTParameters.Windowed = true;
             d3DPRESENTParameters.EnableAutoDepthStencil = true;
             d3DPRESENTParameters.BackBufferWidth = canvas.getWidth();
             d3DPRESENTParameters.BackBufferHeight = canvas.getHeight();
@@ -158,7 +158,6 @@ public class DirectXRenderer extends HardwareRenderer {
 
                 renderer.method8412(canvas);
                 renderer.method14147();
-                System.out.println("got here 15");
                 return renderer;
             }
         }

--- a/src/main/java/com/jagex/MovingAnimation.java
+++ b/src/main/java/com/jagex/MovingAnimation.java
@@ -43,6 +43,7 @@ public class MovingAnimation extends Animation {
         }
     }
 
+
     @Override
     void method7586(AnimationDefinitions animationdefinitions_1, int i_2) {
         if (!aBool7891 || !aTransform_Sub1_Sub1_Sub2_7892.currentAnimation.hasDefs() || aTransform_Sub1_Sub1_Sub2_7892.currentAnimation.hasSpeed()) {

--- a/src/main/java/com/jagex/SkyboxIndexLoader.java
+++ b/src/main/java/com/jagex/SkyboxIndexLoader.java
@@ -45,23 +45,42 @@ public class SkyboxIndexLoader {
                         component.idHash = i + (interfaceId << 16);
                         component.readValues(new ByteBuf(bytes_8));
 
+//                        if(Class158.getScreenMode() >= 2) {
+//                            //Game Window Interface
+//                            if (component.idHash == 48889904) {
+//                                component.basePositionY = 0;
+//                                component.baseHeight = 0;
+//                            }
+//
+//                            //Lobby interface Hashes
+//                            if (component.idHash == 59375616 || component.idHash == 59768835 || component.idHash == 38600709) {
+//                                component.basePositionY = 0;
+//                                component.baseHeight = 0;
+//                            }
+//
+//                            //Banner at top hashes
+//                            if (component.idHash == 59375617 || component.idHash == 48890095 || component.idHash == 35913730) {
+//                                component.baseHeight = 0;
+//                            }
+//                        } else {
+//                            if(component.idHash == 48889904) {
+//                                component.basePositionY = 50;
+//                                component.baseHeight = 50;
+//                            }
+//                            if(component.idHash == 59768835 || component.idHash == 38600709) {
+//                                component.basePositionY = 0;
+//                                component.baseHeight = 0;
+//                            }
+//                            if (component.idHash == 59375616) {
+//                                component.basePositionY = 50;
+//                                component.baseHeight = 50;
+//                            }
+//                            if (component.idHash == 59375617 || component.idHash == 48890095 || component.idHash == 35913730) {
+//                                component.baseHeight = 50;
+//                            }
+//                        }
 
-                        //Game Window Interface
-                        if(component.idHash == 48889904) {
-                            component.basePositionY = 0;
-                            component.baseHeight = 0;
-                        }
 
-                        //Lobby interface Hashes
-                        if(component.idHash == 59375616 || component.idHash == 35913932 || component.idHash == 59768835 || component.idHash == 38600709) {
-                            component.basePositionY = 0;
-                            component.baseHeight = 0;
-                        }
-
-                        //Banner at top hashes
-                        if(component.idHash == 59375617 || component.idHash == 48890095 || component.idHash == 35913730) {
-                            component.baseHeight = 0;
-                        }
                     }
                 }
             }

--- a/src/main/java/com/jagex/SkyboxIndexLoader.java
+++ b/src/main/java/com/jagex/SkyboxIndexLoader.java
@@ -44,6 +44,24 @@ public class SkyboxIndexLoader {
                         IComponentDefinitions component = interface_21.components[i] = new IComponentDefinitions();
                         component.idHash = i + (interfaceId << 16);
                         component.readValues(new ByteBuf(bytes_8));
+
+
+                        //Game Window Interface
+                        if(component.idHash == 48889904) {
+                            component.basePositionY = 0;
+                            component.baseHeight = 0;
+                        }
+
+                        //Lobby interface Hashes
+                        if(component.idHash == 59375616 || component.idHash == 35913932 || component.idHash == 59768835 || component.idHash == 38600709) {
+                            component.basePositionY = 0;
+                            component.baseHeight = 0;
+                        }
+
+                        //Banner at top hashes
+                        if(component.idHash == 59375617 || component.idHash == 48890095 || component.idHash == 35913730) {
+                            component.baseHeight = 0;
+                        }
                     }
                 }
             }

--- a/src/main/java/com/jagex/SkyboxIndexLoader.java
+++ b/src/main/java/com/jagex/SkyboxIndexLoader.java
@@ -44,48 +44,6 @@ public class SkyboxIndexLoader {
                         IComponentDefinitions component = interface_21.components[i] = new IComponentDefinitions();
                         component.idHash = i + (interfaceId << 16);
                         component.readValues(new ByteBuf(bytes_8));
-
-
-                        if(Class158.getScreenMode() >= 2) {
-                            //Game Window Interface
-                            if (component.idHash == 48889904) {
-                                component.basePositionY = 0;
-                                component.baseHeight = 0;
-                            }
-
-                            //Lobby interface Hashes
-                            if (component.idHash == 59375616 || component.idHash == 59768835 || component.idHash == 38600709) {
-                                component.basePositionY = 0;
-                                component.baseHeight = 0;
-                            }
-
-                            //Banner at top hashes
-                            if (component.idHash == 59375617 || component.idHash == 48890095 || component.idHash == 35913730) {
-                                component.baseHeight = 0;
-                            }
-                        } else {
-                            //Game window
-                            if(component.idHash == 48889904) {
-                                component.basePositionY = 50;
-                                component.baseHeight = 50;
-                            }
-                            //Lobby interface
-                            if(component.idHash == 59768835 || component.idHash == 38600709) {
-                                component.basePositionY = 0;
-                                component.baseHeight = 0;
-                            }
-                            //Fixed window interface
-                            if (component.idHash == 59375616) {
-                                component.basePositionY = 50;
-                                component.baseHeight = 50;
-                            }
-                            //Banner at top
-                            if (component.idHash == 59375617 || component.idHash == 48890095 || component.idHash == 35913730) {
-                                component.baseHeight = 50;
-                            }
-                        }
-
-
                     }
                 }
             }

--- a/src/main/java/com/jagex/SkyboxIndexLoader.java
+++ b/src/main/java/com/jagex/SkyboxIndexLoader.java
@@ -17,8 +17,8 @@ public class SkyboxIndexLoader {
         Class407.aCalendar4846.setTime(new Date(long_0));
     }
 
-    public static Interface getInterface(int interfaceId, int[] ints_1, Interface interface_2, boolean bool_3) {
-        Interface interface_21 = interface_2;
+    public static Interface getInterface(int interfaceId, int[] ints_1, Interface inter, boolean bool_3) {
+        Interface interface_21 = inter;
         if (!Class388.INTERFACE_INDEX.loadArchive(interfaceId)) {
             return null;
         } else {
@@ -45,40 +45,45 @@ public class SkyboxIndexLoader {
                         component.idHash = i + (interfaceId << 16);
                         component.readValues(new ByteBuf(bytes_8));
 
-//                        if(Class158.getScreenMode() >= 2) {
-//                            //Game Window Interface
-//                            if (component.idHash == 48889904) {
-//                                component.basePositionY = 0;
-//                                component.baseHeight = 0;
-//                            }
-//
-//                            //Lobby interface Hashes
-//                            if (component.idHash == 59375616 || component.idHash == 59768835 || component.idHash == 38600709) {
-//                                component.basePositionY = 0;
-//                                component.baseHeight = 0;
-//                            }
-//
-//                            //Banner at top hashes
-//                            if (component.idHash == 59375617 || component.idHash == 48890095 || component.idHash == 35913730) {
-//                                component.baseHeight = 0;
-//                            }
-//                        } else {
-//                            if(component.idHash == 48889904) {
-//                                component.basePositionY = 50;
-//                                component.baseHeight = 50;
-//                            }
-//                            if(component.idHash == 59768835 || component.idHash == 38600709) {
-//                                component.basePositionY = 0;
-//                                component.baseHeight = 0;
-//                            }
-//                            if (component.idHash == 59375616) {
-//                                component.basePositionY = 50;
-//                                component.baseHeight = 50;
-//                            }
-//                            if (component.idHash == 59375617 || component.idHash == 48890095 || component.idHash == 35913730) {
-//                                component.baseHeight = 50;
-//                            }
-//                        }
+
+                        if(Class158.getScreenMode() >= 2) {
+                            //Game Window Interface
+                            if (component.idHash == 48889904) {
+                                component.basePositionY = 0;
+                                component.baseHeight = 0;
+                            }
+
+                            //Lobby interface Hashes
+                            if (component.idHash == 59375616 || component.idHash == 59768835 || component.idHash == 38600709) {
+                                component.basePositionY = 0;
+                                component.baseHeight = 0;
+                            }
+
+                            //Banner at top hashes
+                            if (component.idHash == 59375617 || component.idHash == 48890095 || component.idHash == 35913730) {
+                                component.baseHeight = 0;
+                            }
+                        } else {
+                            //Game window
+                            if(component.idHash == 48889904) {
+                                component.basePositionY = 50;
+                                component.baseHeight = 50;
+                            }
+                            //Lobby interface
+                            if(component.idHash == 59768835 || component.idHash == 38600709) {
+                                component.basePositionY = 0;
+                                component.baseHeight = 0;
+                            }
+                            //Fixed window interface
+                            if (component.idHash == 59375616) {
+                                component.basePositionY = 50;
+                                component.baseHeight = 50;
+                            }
+                            //Banner at top
+                            if (component.idHash == 59375617 || component.idHash == 48890095 || component.idHash == 35913730) {
+                                component.baseHeight = 50;
+                            }
+                        }
 
 
                     }


### PR DESCRIPTION
Found a solution to the remove banner update from a year ago. If you switch to and from fixed mode from the lobby while updating the components back to the previous values you can have resizeable without the banner and fixed with it.

_Fixed_
![image](https://user-images.githubusercontent.com/27308928/148435658-714065e8-88a0-4d18-8084-9ae3063d3f86.png)

_Resizeable_
![image](https://user-images.githubusercontent.com/27308928/148435755-e8c25216-f824-4845-80e6-6aad66d8414f.png)

_And, freaking womp, full screen_
![image](https://user-images.githubusercontent.com/27308928/148435893-fbd60ed9-52cf-40a7-8d86-91bee3ca6092.png)

Also, fullscreen crash cases have been avoided by sticking to OpenGL for fullscreen. I havn't been able to crash it